### PR TITLE
Export HADOOP_CONF_DIR during spark-submit in operator pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The Kubernetes Operator for Apache Spark currently supports the following list o
 
 Nokia CSF Contributions
 * Support for SSL enabled driver UI (https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/490)
+* Copy hadoop-site xmls present in hadoopConfigMap to operator pod and export HADOOP_CONF_DIR during spark-submit (https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/572)
   
 ## Contributing
 

--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+	"os"
+)
+
+const mntDir = "/mnt/"
+
+type getCm struct {
+	configMap *v1.ConfigMap
+}
+
+type dynamicCopy interface {
+	copyResourceToFile(appNamespace string, appName string, resourceName string) (string, []string, error)
+}
+
+// Here, copyResourceToFile is a receiver function implementing dynamicCopy interface on getCm
+// It copies configmap content to files and returns the location of the configmap files including the filename
+func (gc getCm) copyResourceToFile(appNamespace string, appName string, cmName string) (string, []string, error) {
+	var returnedpath string
+	var filesInConfigMap []string
+	for key := range gc.configMap.Data {
+		pathVal := mntDir + appNamespace + "/" + appName + "/" + cmName
+		err := os.MkdirAll(pathVal, 0770)
+		if err != nil {
+			glog.Errorf("%v", err)
+			return "", nil, err
+		}
+
+		pathValKey := pathVal + "/" + key
+		f, err := os.Create(pathValKey)
+		if err != nil {
+			glog.Errorf("%v", err)
+			return "", nil, err
+		} else {
+			glog.V(2).Infof("%s created successfully", pathValKey)
+		}
+
+		defer f.Close()
+		f.WriteString(gc.configMap.Data[key])
+		filesInConfigMap = append(filesInConfigMap, key)
+		returnedpath = pathVal
+	}
+	return returnedpath, filesInConfigMap, nil
+}
+
+// If a variable has an interface type, then we can call methods that are in the named interface
+// So, instance of getCm struct can be used as argument to copyToFile function
+func copyToFile(d dynamicCopy, appNamespace string, appName string, resourceName string) (string, error) {
+	path, key, err := d.copyResourceToFile(appNamespace, appName, resourceName)
+	if err != nil {
+		return "", err
+	}
+	_ = key
+	return path, nil
+}
+
+// RemoveDirectory removes the directory where configmaps and secrets are dynamically copied
+func RemoveDirectory(appNamespace string, appName string) {
+	var dirToRemove = mntDir + appNamespace + "/" + appName
+	err := os.RemoveAll(dirToRemove)
+	if err != nil {
+		glog.Errorf("%v", err)
+	} else {
+		glog.V(2).Infof("Deleting %s if it exists", dirToRemove)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,11 @@ package config
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	res "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta1"
 )
 
@@ -55,4 +60,37 @@ func GetExecutorEnvVarConfOptions(app *v1beta1.SparkApplication) []string {
 // GetPrometheusConfigMapName returns the name of the ConfigMap for Prometheus configuration.
 func GetPrometheusConfigMapName(app *v1beta1.SparkApplication) string {
 	return fmt.Sprintf("%s-%s", app.Name, PrometheusConfigMapNameSuffix)
+}
+
+// GetK8sConfigMap gets the cmName configmap in app.Namespace and returns the configMapPath
+func GetK8sConfigMap(app *v1beta1.SparkApplication, cmName string) (string, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		glog.Errorf("%v", err)
+		return "", err
+	}
+
+	clientset, err := res.NewForConfig(config)
+	if err != nil {
+		glog.Errorf("%v", err)
+		return "", err
+	}
+
+	configMapsInNamespace := clientset.ConfigMaps(app.Namespace)
+	userProvidedConfigMap, err := configMapsInNamespace.Get(cmName, metav1.GetOptions{})
+
+	if err != nil {
+		glog.Errorf("%v", err)
+		return "", err
+	}
+
+	configFound := getCm{configMap: userProvidedConfigMap}
+
+	configMapPath, err := copyToFile(configFound, app.Namespace, app.Name, cmName)
+	if err != nil {
+		glog.Errorf("%v", err)
+		return "", err
+	}
+
+	return configMapPath, nil
 }

--- a/pkg/controller/sparkapplication/controller.go
+++ b/pkg/controller/sparkapplication/controller.go
@@ -416,6 +416,8 @@ func (c *Controller) handleSparkApplicationDeletion(app *v1beta1.SparkApplicatio
 	// SparkApplication deletion requested, lets delete driver pod.
 	if err := c.deleteSparkResources(app); err != nil {
 		glog.Errorf("failed to delete resources associated with deleted SparkApplication %s/%s: %v", app.Namespace, app.Name, err)
+		// SparkApplication deletion requested, lets delete directory where hadoopConfigMap site xmls were copied.
+		config.RemoveDirectory(app.Namespace, app.Name)
 	}
 }
 
@@ -609,7 +611,7 @@ func (c *Controller) submitSparkApplication(app *v1beta1.SparkApplication) *v1be
 
 	driverPodName := getDriverPodName(app)
 	submissionID := uuid.New().String()
-	submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
+	exportEnvVars, submissionCmdArgs, err := buildSubmissionCommandArgs(app, driverPodName, submissionID)
 	if err != nil {
 		app.Status = v1beta1.SparkApplicationStatus{
 			AppState: v1beta1.ApplicationState{
@@ -634,7 +636,7 @@ func (c *Controller) submitSparkApplication(app *v1beta1.SparkApplication) *v1be
 	}
 
 	// Try submitting the application by running spark-submit.
-	submitted, err := runSparkSubmit(newSubmission(submissionCmdArgs, app))
+	submitted, err := runSparkSubmit(exportEnvVars, newSubmission(submissionCmdArgs, app))
 	if err != nil {
 		app.Status = v1beta1.SparkApplicationStatus{
 			AppState: v1beta1.ApplicationState{
@@ -861,6 +863,7 @@ func (c *Controller) recordSparkApplicationEvent(app *v1beta1.SparkApplication) 
 			"SparkApplication %s was submitted successfully",
 			app.Name)
 	case v1beta1.FailedSubmissionState:
+		config.RemoveDirectory(app.Namespace, app.Name)
 		c.recorder.Eventf(
 			app,
 			apiv1.EventTypeWarning,
@@ -869,6 +872,7 @@ func (c *Controller) recordSparkApplicationEvent(app *v1beta1.SparkApplication) 
 			app.Name,
 			app.Status.AppState.ErrorMessage)
 	case v1beta1.CompletedState:
+		config.RemoveDirectory(app.Namespace, app.Name)
 		c.recorder.Eventf(
 			app,
 			apiv1.EventTypeNormal,
@@ -876,6 +880,7 @@ func (c *Controller) recordSparkApplicationEvent(app *v1beta1.SparkApplication) 
 			"SparkApplication %s completed",
 			app.Name)
 	case v1beta1.FailedState:
+		config.RemoveDirectory(app.Namespace, app.Name)
 		c.recorder.Eventf(
 			app,
 			apiv1.EventTypeWarning,
@@ -884,6 +889,7 @@ func (c *Controller) recordSparkApplicationEvent(app *v1beta1.SparkApplication) 
 			app.Name,
 			app.Status.AppState.ErrorMessage)
 	case v1beta1.PendingRerunState:
+		config.RemoveDirectory(app.Namespace, app.Name)
 		c.recorder.Eventf(
 			app,
 			apiv1.EventTypeWarning,

--- a/pkg/controller/sparkapplication/submission.go
+++ b/pkg/controller/sparkapplication/submission.go
@@ -52,16 +52,27 @@ func newSubmission(args []string, app *v1beta1.SparkApplication) *submission {
 	}
 }
 
-func runSparkSubmit(submission *submission) (bool, error) {
+func runSparkSubmit(exportEnvVars []string, submission *submission) (bool, error) {
 	sparkHome, present := os.LookupEnv(sparkHomeEnvVar)
 	if !present {
 		glog.Error("SPARK_HOME is not specified")
 	}
 	var command = filepath.Join(sparkHome, "/bin/spark-submit")
+	var cmd *exec.Cmd
 
-	cmd := execCommand(command, submission.args...)
+	// exportEnvVars is not nil when .ap.Spec.HadoopConfigMap is specified for spark-jobs
+	// exporting HADOOP_CONF_DIR during spark-submit
+	if exportEnvVars != nil {
+		exportEnvVarsToString := strings.Join(exportEnvVars, " ")
+		argsToString := strings.Join(submission.args, " ")
+		result := exportEnvVarsToString + command + " " + argsToString
+		cmd = execCommand("/bin/sh", "-c", result)
+	} else {
+		cmd = execCommand(command, submission.args...)
+	}
+
 	glog.V(2).Infof("spark-submit arguments: %v", cmd.Args)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	glog.V(3).Infof("spark-submit output: %s", string(output))
 	if err != nil {
 		var errorMsg string
@@ -82,14 +93,17 @@ func runSparkSubmit(submission *submission) (bool, error) {
 	return true, nil
 }
 
-func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName string, submissionID string) ([]string, error) {
+func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName string, submissionID string) ([]string, []string,
+	error) {
 	var args []string
+	var exportenv []string
+
 	if app.Spec.MainClass != nil {
 		args = append(args, "--class", *app.Spec.MainClass)
 	}
 	masterURL, err := getMasterURL()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	args = append(args, "--master", masterURL)
@@ -129,6 +143,17 @@ func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName str
 	// Operator triggered spark-submit should never wait for App completion
 	args = append(args, "--conf", fmt.Sprintf("%s=false", config.SparkWaitAppCompletion))
 
+	if app.Spec.HadoopConfigMap != nil {
+		// Copy hadoop config files to operator pod
+		hadoopConfLoc, err := config.GetK8sConfigMap(app, *app.Spec.HadoopConfigMap)
+		if err != nil {
+			glog.Errorf("%v", err)
+			return nil, nil, err
+		}
+		// Setting HADOOP_CONF_DIR
+		exportenv = append(exportenv, fmt.Sprintf("export HADOOP_CONF_DIR=%s;", hadoopConfLoc))
+	}
+
 	// Add Spark configuration properties.
 	for key, value := range app.Spec.SparkConf {
 		// Configuration property for the driver pod name has already been set.
@@ -152,14 +177,14 @@ func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName str
 	// so init-container is not needed and therefore no init-container image needs to be specified.
 	options, err := addDriverConfOptions(app, submissionID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, option := range options {
 		args = append(args, "--conf", option)
 	}
 	options, err = addExecutorConfOptions(app, submissionID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, option := range options {
 		args = append(args, "--conf", option)
@@ -175,7 +200,7 @@ func buildSubmissionCommandArgs(app *v1beta1.SparkApplication, driverPodName str
 		args = append(args, argument)
 	}
 
-	return args, nil
+	return exportenv, args, nil
 }
 
 func getMasterURL() (string, error) {


### PR DESCRIPTION
Export HADOOP_CONF_DIR during spark-submit in operator pod by copying hadoop site xmls present in hadoopConfigMap to operator pod.